### PR TITLE
Update bitlocker-use-bitlocker-recovery-password-viewer.md

### DIFF
--- a/windows/security/information-protection/bitlocker/bitlocker-use-bitlocker-recovery-password-viewer.md
+++ b/windows/security/information-protection/bitlocker/bitlocker-use-bitlocker-recovery-password-viewer.md
@@ -63,7 +63,7 @@ The following procedures describe the most common tasks performed by using the B
 
 By completing the procedures in this scenario, the recovery passwords for a computer have been viewed and copied and a password ID was used to locate a recovery password.
 
-## Replated articles
+## Related articles
 
 - [BitLocker Overview](bitlocker-overview.md)
 - [BitLocker frequently asked questions (FAQ)](bitlocker-frequently-asked-questions.yml)


### PR DESCRIPTION
## Fixing typo
The word "Replated" should be "Related".

## Why
It looks typo since the word "Replated" doesn't fit to the context.

- Closes #[Issue Number]

## Changes
- Replated -> Related
